### PR TITLE
Changes for T-Watch 2020

### DIFF
--- a/AWatch/AWatch.ino
+++ b/AWatch/AWatch.ino
@@ -14,7 +14,8 @@
 */
 
 #define LILYGO_TWATCH_2020_V1        // If you are using T-Watch-2020 version, please open this macro definition
-
+#include "SPIFFS.h"
+#include "AudioFileSourceSPIFFS.h"
 #include <TTGO.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -28,9 +29,9 @@
 //#include "elysium.h"
 //#include "chaos.h"
 //#include "pxloader.h"
-#include "SPIFFS.h"
+
 //#include "AudioFileSourcePROGMEM.h"
-#include "AudioFileSourceSPIFFS.h"
+
 #include "AudioGeneratorMOD.h"
 #include "AudioOutputI2S.h"
 #include <ESP8266SAM.h>
@@ -46,8 +47,8 @@ uint8_t last_sec = 0;
 unsigned char songs[3];
 char saytext[64];
 AudioGeneratorMOD *mod;
-//AudioFileSourceSPIFFS *file;
-AudioFileSourcePROGMEM *file;
+AudioFileSourceSPIFFS *file;
+//AudioFileSourcePROGMEM *file;
 //AudioFileSourcePROGMEM *s1;
 //AudioFileSourcePROGMEM *s2;
 AudioOutputI2S *out;
@@ -443,15 +444,18 @@ void loop()
          
     switch(song_index){
       case 0:
-        file = new AudioFileSourcePROGMEM(ELYSIUM_MOD, sizeof(ELYSIUM_MOD) );
+        //file = new AudioFileSourcePROGMEM(ELYSIUM_MOD, sizeof(ELYSIUM_MOD) );
+        file = new AudioFileSourceSPIFFS("/ELYSIUM.MOD");
         mod->begin(file, out);
         break;
       case 1:
-        file = new AudioFileSourcePROGMEM(Chaos_Engine_k8_mod, sizeof(Chaos_Engine_k8_mod) );
+        //file = new AudioFileSourcePROGMEM(Chaos_Engine_k8_mod, sizeof(Chaos_Engine_k8_mod) );
+        file = new AudioFileSourceSPIFFS("/enigma.mod");
         mod->begin(file, out);
         break;
       case 2: 
-        file = new AudioFileSourcePROGMEM(Project_X_RE_pxloader_mod, sizeof(Project_X_RE_pxloader_mod) );  
+        //file = new AudioFileSourcePROGMEM(Project_X_RE_pxloader_mod, sizeof(Project_X_RE_pxloader_mod) );  
+        file = new AudioFileSourceSPIFFS("/aurora.mod");
         mod->begin(file, out);
         break;
       default:

--- a/AWatch/AWatch.ino
+++ b/AWatch/AWatch.ino
@@ -13,7 +13,7 @@
   git clone https://github.com/bblanchon/ArduinoJson.git
 */
 
-// #define LILYGO_TWATCH_2020_V1        // If you are using T-Watch-2020 version, please open this macro definition
+#define LILYGO_TWATCH_2020_V1        // If you are using T-Watch-2020 version, please open this macro definition
 
 #include <TTGO.h>
 #include "freertos/FreeRTOS.h"
@@ -161,9 +161,10 @@ void setup()
   //s0 = new AudioFileSourcePROGMEM( ELYSIUM_MOD, sizeof(ELYSIUM_MOD) );
   //s1 = new AudioFileSourcePROGMEM( Chaos_Engine_k8_mod, sizeof(Chaos_Engine_k8_mod) );
   //s2 = new AudioFileSourcePROGMEM( Project_X_RE_pxloader_mod, sizeof(Project_X_RE_pxloader_mod) );  
-
+  #ifndef LILYGO_TWATCH_2020_V1
   out = new AudioOutputI2S(0, 1);
   out->begin();
+  #endif
   
   //out->SetGain((70.0)/100.0);
   //out->SetGain(((float)40)/100.0);
@@ -256,6 +257,14 @@ void setup()
     }
   }, FALLING);
   //ttgo->power->setTimer(1); // Set AXP Timer
+  
+  #ifdef LILYGO_TWATCH_2020_V1
+  ttgo->eTFT->setRotation(2);
+  out = new AudioOutputI2S();
+  out->SetPinout(TWATCH_DAC_IIS_BCK, TWATCH_DAC_IIS_WS, TWATCH_DAC_IIS_DOUT);
+  out->begin();
+  #endif
+  
   //Check if the RTC clock matches, if not, use compile time
   ttgo->rtc->check();
 


### PR DESCRIPTION
Audio needs to use external DAC on the 2020 Version, also it needs to be set up after bma and axp or these will not initialise.
Also rotate the display correctly.